### PR TITLE
update python version in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
+    - "3.5"
+    - "3.6"
 # command to install dependencies
 install:
   - pip install -U pip


### PR DESCRIPTION
updates to the same python versions we test MDAnalysis against. With 3.4 being the oldest supported version. This will also improve CI speeds since there are pandas wheels for 3.4+