### PR TITLE
Remove pandas `as_matrix() deprecated method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
 # command to install dependencies

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ function—that gets the path to an EDR file and returns a pandas
 dataframe.
 
 ``panedr`` is compatible with python 2.7 and greater, and with
-python 3.3 and greater.
+python 3.5 and greater.
 
 Example
 -------

--- a/panedr/tests/test_edr.py
+++ b/panedr/tests/test_edr.py
@@ -94,14 +94,14 @@ class TestEdrToDf(object):
         """
         Test that the time is read correctly when dt is regular.
         """
-        time = edr.df[u'Time'].as_matrix()
+        time = edr.df[u'Time'].values
         assert numpy.allclose(edr.xvgtime, time, atol=5e-7)
 
     def test_content(self, edr):
         """
         Test that the content of the DataFrame is the expected one.
         """
-        content = edr.df.iloc[:, 1:].as_matrix()
+        content = edr.df.iloc[:, 1:].values
         print(edr.xvgdata - content)
         assert numpy.allclose(edr.xvgdata, content, atol=edr.xvgprec/2)
 
@@ -112,7 +112,7 @@ class TestEdrToDf(object):
         with redirect_stderr(sys.stdout):
             df = panedr.edr_to_df(EDR, verbose=True)
         ref_content, _, prec = read_xvg(EDR_XVG)
-        content = df.as_matrix()
+        content = df.values
         print(ref_content - content)
         assert numpy.allclose(ref_content, content, atol=prec/2)
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(name='panedr',
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.3',
-                   'Programming Language :: Python :: 3.4',
+                   'Programming Language :: Python :: 3.5',
+                   'Programming Language :: Python :: 3.6',
 
                    'Operating System :: OS Independent',
                    ],
@@ -41,5 +41,6 @@ setup(name='panedr',
       test_suite='panedr.tests',
       tests_require=tests_require,
       extras_require={'test': tests_require},
-      package_data={'panedr': ['VERSION', 'tests/test*.py', 'tests/data/*']}
+      package_data={'panedr': ['VERSION', 'tests/test*.py', 'tests/data/*']},
+      python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
       )


### PR DESCRIPTION
The method is replaced by the `values` property of Series