### PR TITLE
Accept `pathlib.Path`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 # command to install dependencies
 install:
   - pip install -U pip
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install pathlib2; fi
   - pip install .[test]
 
 # command to run tests

--- a/panedr/panedr.py
+++ b/panedr/panedr.py
@@ -396,7 +396,7 @@ def is_frame_magic(data):
 
 def edr_to_df(path, verbose=False):
     begin = time.time()
-    edr_file = EDRFile(path)
+    edr_file = EDRFile(str(path))
     all_energies = []
     all_names = [u'Time'] + [nm.name for nm in edr_file.nms]
     times = []

--- a/panedr/tests/test_edr.py
+++ b/panedr/tests/test_edr.py
@@ -31,7 +31,11 @@ except ImportError:
         from io import StringIO
 
 from collections import namedtuple
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    # Python 2 requires the pathlib2 backport of pathlib
+    from pathlib2 import Path
 
 # Constants for XVG parsing
 COMMENT_PATTERN = re.compile('\s*[@#%&/]')

--- a/panedr/tests/test_edr.py
+++ b/panedr/tests/test_edr.py
@@ -31,6 +31,7 @@ except ImportError:
         from io import StringIO
 
 from collections import namedtuple
+from pathlib import Path
 
 # Constants for XVG parsing
 COMMENT_PATTERN = re.compile('\s*[@#%&/]')
@@ -54,7 +55,9 @@ EDR_Data = namedtuple('EDR_Data', ['df', 'xvgdata', 'xvgtime', 'xvgnames',
 @pytest.fixture(scope='module',
                 params=[(EDR, EDR_XVG),
                         (EDR_IRREGULAR, EDR_IRREGULAR_XVG),
-                        (EDR_DOUBLE, EDR_DOUBLE_XVG)])
+                        (EDR_DOUBLE, EDR_DOUBLE_XVG),
+                        (Path(EDR), EDR_XVG),
+                       ])
 def edr(request):
     edrfile, xvgfile = request.param
     df = panedr.edr_to_df(edrfile)


### PR DESCRIPTION
Instances of `pathlib.Path` can now be used as argument for `edr_to_df`. Tests and travis are adapted. Travis installs pathlib2 on python 2.7.