### PR TITLE
Test on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
+# Enable 3.7 without globally enabling sudo and dist: xenial for
+# other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 # command to install dependencies
 install:
   - pip install -U pip


### PR DESCRIPTION
I'm having an issue with Python 3.7 that might be related to this package, so it would be nice to do the testing here to ensure it works in the latest Python.

Unfortunately, Travis-CI's default of Ubuntu 14.04 doesn't work with the new version, so you need to specify Ubuntu 16.04 Xenial. The addition is based on the Python 3.7 issue on Travis-CI (https://github.com/travis-ci/travis-ci/issues/9815).