### PR TITLE
Fix typo in __version__

### DIFF
--- a/panedr/__init__.py
+++ b/panedr/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pbr.version
-__version__ = pbr.version.VersionInfo('vermouth').release_string()
+__version__ = pbr.version.VersionInfo('panedr').release_string()
 del pbr
 
 from .panedr import *


### PR DESCRIPTION
The line was copy pasted from vermouth and kept the reference to the
wrong package.

Fixes #20